### PR TITLE
Correcion de los logs de los tunneles

### DIFF
--- a/configure_logger.py
+++ b/configure_logger.py
@@ -5,7 +5,7 @@ from logging.handlers import TimedRotatingFileHandler
 
 class LogManager:
 
-    path = "./"
+    path = "./logs"
 
     @staticmethod
     def configure_logger(filename, level=None, log_to_console=False, name="pytun"):

--- a/pytun.py
+++ b/pytun.py
@@ -78,7 +78,7 @@ def main():
         if not os.path.isdir(log_path):
             os.mkdir(log_path)
     LogManager.path = log_path
-    TunnelProcess.log_path = log_path
+    TunnelProcess.default_log_path = log_path
     logger = LogManager.configure_logger('main_connector.log', params.get("log_level", "INFO"), test_something)
     if tunnel_manager_id is None:
         logger.error("tunnel_manager_id not set in the config file")

--- a/pytun.py
+++ b/pytun.py
@@ -78,6 +78,7 @@ def main():
         if not os.path.isdir(log_path):
             os.mkdir(log_path)
     LogManager.path = log_path
+    TunnelProcess.log_path = log_path
     logger = LogManager.configure_logger('main_connector.log', params.get("log_level", "INFO"), test_something)
     if tunnel_manager_id is None:
         logger.error("tunnel_manager_id not set in the config file")

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -57,7 +57,7 @@ class TunnelProcess(multiprocessing.Process):
     def run(self):
         LogManager.path = self.log_path
         self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
-                                                  name="pytun-tunnel")
+                                                  name="pyconn-coonnector")
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGTERM, self.exit_gracefully)
         client = self.ssh_connect()

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -139,5 +139,5 @@ class TunnelProcess(multiprocessing.Process):
         tunnel_process = TunnelProcess(tunnel_name, server_host, server_port, server_key, user_to_login, key_file,
                                        remote_port_to_forward, remote_host, remote_port, keep_alive_time, log_level,
                                        log_to_console, alert_senders=alert_senders, log_filename=log_filename,
-                                       log_path=TunnelProcess.log_path)
+                                       log_path=TunnelProcess.default_log_path)
         return tunnel_process

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -29,8 +29,6 @@ class TunnelProcess(multiprocessing.Process):
             self.log_path = log_path
         else:
             self.log_path = TunnelProcess.default_log_path
-
-        print('ssssssssssssssss',self.log_path)
         self.tunnel_name = tunnel_name
         self.server_host = server_host
         self.server_port = server_port
@@ -47,9 +45,6 @@ class TunnelProcess(multiprocessing.Process):
         self.log_to_console = log_to_console
         self.alert_senders = alert_senders
 
-        LogManager.path = self.log_path
-        self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
-                                                  name="pytun-tunnel")
         super().__init__()
 
     def exit_gracefully(self, *args):
@@ -63,7 +58,9 @@ class TunnelProcess(multiprocessing.Process):
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGTERM, self.exit_gracefully)
         client = self.ssh_connect()
-
+        LogManager.path = self.log_path
+        self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
+                                                  name="pytun-tunnel")
         self.logger.info(
             "Now forwarding remote port %d to %s:%d ..."
             % (self.remote_port_to_forward, self.remote_host, self.remote_port)
@@ -142,5 +139,5 @@ class TunnelProcess(multiprocessing.Process):
         tunnel_process = TunnelProcess(tunnel_name, server_host, server_port, server_key, user_to_login, key_file,
                                        remote_port_to_forward, remote_host, remote_port, keep_alive_time, log_level,
                                        log_to_console, alert_senders=alert_senders, log_filename=log_filename,
-                                       log_path=TunnelProcess.default_log_path)
+                                       log_path=TunnelProcess.log_path)
         return tunnel_process

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -27,6 +27,7 @@ class TunnelProcess(multiprocessing.Process):
         self.log_filename = log_filename
         if log_path:
             TunnelProcess.log_path = log_path
+        print('EL LOG PATH ES TUNNEL', TunnelProcess.log_path)
         self.tunnel_name = tunnel_name
         self.server_host = server_host
         self.server_port = server_port
@@ -42,6 +43,10 @@ class TunnelProcess(multiprocessing.Process):
         self.log_level = log_level
         self.log_to_console = log_to_console
         self.alert_senders = alert_senders
+
+        LogManager.path = TunnelProcess.log_path
+        self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
+                                                  name="pytun-tunnel")
         super().__init__()
 
     def exit_gracefully(self, *args):
@@ -52,9 +57,6 @@ class TunnelProcess(multiprocessing.Process):
         sys.exit(0)
 
     def run(self):
-        LogManager.path = TunnelProcess.log_path
-        self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
-                                                  name="pytun-tunnel")
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGTERM, self.exit_gracefully)
         client = self.ssh_connect()

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -55,11 +55,11 @@ class TunnelProcess(multiprocessing.Process):
         sys.exit(0)
 
     def run(self):
-        signal.signal(signal.SIGINT, self.exit_gracefully)
-        signal.signal(signal.SIGTERM, self.exit_gracefully)
         LogManager.path = self.log_path
         self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
                                                   name="pytun-tunnel")
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
         client = self.ssh_connect()
 
         self.logger.info(

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -17,7 +17,7 @@ DEFAULT_PORT = 4000
 
 
 class TunnelProcess(multiprocessing.Process):
-    log_path = './logs'
+    default_log_path = './logs'
 
     def __init__(self, tunnel_name, server_host, server_port, server_key, user_to_login, key_file, remote_port_to_forward,
                  remote_host, remote_port, keep_alive_time, log_level, log_to_console, alert_senders=None,
@@ -26,8 +26,11 @@ class TunnelProcess(multiprocessing.Process):
             log_filename = os.path.splitext(os.path.basename(tunnel_name))[0] + ".log"
         self.log_filename = log_filename
         if log_path:
-            TunnelProcess.log_path = log_path
-        print('EL LOG PATH ES TUNNEL', TunnelProcess.log_path)
+            self.log_path = log_path
+        else:
+            self.log_path = TunnelProcess.default_log_path
+
+        print('ssssssssssssssss',self.log_path)
         self.tunnel_name = tunnel_name
         self.server_host = server_host
         self.server_port = server_port
@@ -44,7 +47,7 @@ class TunnelProcess(multiprocessing.Process):
         self.log_to_console = log_to_console
         self.alert_senders = alert_senders
 
-        LogManager.path = TunnelProcess.log_path
+        LogManager.path = self.log_path
         self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
                                                   name="pytun-tunnel")
         super().__init__()
@@ -139,5 +142,5 @@ class TunnelProcess(multiprocessing.Process):
         tunnel_process = TunnelProcess(tunnel_name, server_host, server_port, server_key, user_to_login, key_file,
                                        remote_port_to_forward, remote_host, remote_port, keep_alive_time, log_level,
                                        log_to_console, alert_senders=alert_senders, log_filename=log_filename,
-                                       log_path=TunnelProcess.log_path)
+                                       log_path=TunnelProcess.default_log_path)
         return tunnel_process

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -115,6 +115,13 @@ class TunnelProcess(multiprocessing.Process):
         log_level = defaults.get('log_level', 'DEBUG')
         log_to_console = defaults.get('log_to_console', False)
         log_path = defaults.get('log_path', './logs')
+        if not isabs(log_path):
+            log_path = join(dirname(realpath(__file__)), log_path)
+            # Hack: sometimes when running on windows with pyinstaller and shawl a "\\?\" is added to cwd and it fails
+            if log_path.startswith("\\\\?\\"):
+                log_path = log_path.replace("\\\\?\\", "")
+            if not os.path.isdir(log_path):
+                os.mkdir(log_path)
         server_host = defaults['server_host']
         server_port = int(defaults.get('server_port', SSH_PORT))
         remote_host = defaults['remote_host']

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -57,7 +57,7 @@ class TunnelProcess(multiprocessing.Process):
     def run(self):
         LogManager.path = self.log_path
         self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
-                                                  name="pyconn-coonnector")
+                                                  name="pyconn-connector")
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGTERM, self.exit_gracefully)
         client = self.ssh_connect()

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -57,10 +57,11 @@ class TunnelProcess(multiprocessing.Process):
     def run(self):
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGTERM, self.exit_gracefully)
-        client = self.ssh_connect()
         LogManager.path = self.log_path
         self.logger = LogManager.configure_logger(self.log_filename, self.log_level, self.log_to_console,
                                                   name="pytun-tunnel")
+        client = self.ssh_connect()
+
         self.logger.info(
             "Now forwarding remote port %d to %s:%d ..."
             % (self.remote_port_to_forward, self.remote_host, self.remote_port)

--- a/tunnel_infra/TunnelProcess.py
+++ b/tunnel_infra/TunnelProcess.py
@@ -124,7 +124,10 @@ class TunnelProcess(multiprocessing.Process):
         remote_host = defaults['remote_host']
         remote_port = int(defaults.get('remote_port', SSH_PORT))
         remote_port_to_forward = int(defaults.get('port', DEFAULT_PORT))
-        tunnel_name = defaults.get('connector_name', realpath(ini_file))
+        if 'connector_name' in defaults:
+            tunnel_name = defaults.get('connector_name', realpath(ini_file))
+        else:
+            tunnel_name = defaults.get('tunnel_name', realpath(ini_file))
         log_filename = os.path.basename(ini_file)
         log_filename = os.path.splitext(log_filename)[0] + ".log"
         key_file = defaults.get('keyfile')


### PR DESCRIPTION
Se agrega una propiedad extra al objeto de tunnel donde almacenara el path, por defecto es _./logs_ de esta forma es posible obtener dentro del handler de introspection.