### PR TITLE
Fix rate limit

### DIFF
--- a/lib/ratelimit.py
+++ b/lib/ratelimit.py
@@ -15,7 +15,7 @@ def ratelimit_by_args(*args, **kwargs):
         def wrapper(*func_args, **func_kwargs):
             f_args_str = "__".join(f"{x}" for x in func_args) + "_" + "__".join(
                 f"{x}" for x in sorted(func_kwargs.items()))
-            func_signature = f"'{func.__name__}{f_args_str}'"
+            func_signature = f'"{func.__name__}{f_args_str}"'
 
             if func_signature not in rate_limits:
                 name = getattr(kwargs, 'name', func_signature)

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 
 def get_version():
     return __version__


### PR DESCRIPTION
Fixes bug that happened when there were strings in the kwargs and the ratelimit library wouldn't work because some char escaping when formatting the string to check in the ratelimit database