### PR TITLE
Add hack to delete old pyinstaller _MEI folders

### DIFF
--- a/pytun.py
+++ b/pytun.py
@@ -36,8 +36,8 @@ _MAC_ADDRESS_CFG_KEY = "signature"
 
 
 def main():
-    application_path = get_application_path()
     clean_runtime_tempdir()
+    application_path = get_application_path()
     parser = argparse.ArgumentParser(description='Tunnel')
     parser.add_argument("--config_ini", dest="config_ini", help="Configuration file to use", default=INI_FILENAME,
                         type=PathType(dash_ok=False))

--- a/pytun.py
+++ b/pytun.py
@@ -26,7 +26,7 @@ from observation.http_server import inspection_http_server
 from observation.status import Status
 from tunnel_infra.TunnelProcess import TunnelProcess
 from tunnel_infra.pathtype import PathType
-from utils import get_application_path
+from utils import get_application_path, clean_runtime_tempdir
 from version import __version__
 
 freeze_support()
@@ -37,6 +37,7 @@ _MAC_ADDRESS_CFG_KEY = "signature"
 
 def main():
     application_path = get_application_path()
+    clean_runtime_tempdir()
     parser = argparse.ArgumentParser(description='Tunnel')
     parser.add_argument("--config_ini", dest="config_ini", help="Configuration file to use", default=INI_FILENAME,
                         type=PathType(dash_ok=False))

--- a/pytun.py
+++ b/pytun.py
@@ -36,7 +36,6 @@ _MAC_ADDRESS_CFG_KEY = "signature"
 
 
 def main():
-    clean_runtime_tempdir()
     application_path = get_application_path()
     parser = argparse.ArgumentParser(description='Tunnel')
     parser.add_argument("--config_ini", dest="config_ini", help="Configuration file to use", default=INI_FILENAME,
@@ -87,6 +86,8 @@ def main():
     TunnelProcess.default_log_path = log_path
     logger = LogManager.configure_logger('main_connector.log', params.get("log_level", "INFO"), test_something)
     device = Device(mac_address_signature=params.get(_MAC_ADDRESS_CFG_KEY))
+
+    clean_runtime_tempdir(logger=logger)
 
     if (test_something or args.test_all) and not device.is_authorized():
         coloredlogs.install(level='DEBUG', logger=logger)

--- a/utils.py
+++ b/utils.py
@@ -54,7 +54,7 @@ def clean_runtime_tempdir(time_threshold: int = 15*60) -> None:
     current_mei_folder_path = os.path.abspath(get_bundle_path())
 
     # directory that contains the _MEI folders
-    temps_dir = os.path.join(current_mei_folder_path, '..')
+    temps_dir = os.path.abspath(os.path.join(current_mei_folder_path, '..'))
 
     now = time.time()
     for mei_folder_path in [f.path for f in os.scandir(temps_dir) if f.is_dir()]:

--- a/utils.py
+++ b/utils.py
@@ -40,7 +40,7 @@ def clean_runtime_tempdir():
     current_mei_folder_path = os.path.abspath(get_bundle_path())
     print(f"{current_mei_folder_path=}")
 
-    for mei_folder_path in [f.name for f in os.scandir(temps_dir) if f.is_dir()]:
+    for mei_folder_path in [f.path for f in os.scandir(temps_dir) if f.is_dir()]:
         print(f"{mei_folder_path=}")
 
         if mei_folder_path == current_mei_folder_path:

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 
 import psutil
@@ -24,3 +25,32 @@ def get_net_if_mac_addresses():
         for snic in snics:
             if snic.family == psutil.AF_LINK:
                 yield interface, snic.address.lower().replace('-', ':')
+
+
+def clean_runtime_tempdir():
+    # hack to clean the pyinstaller runtime tempdir as the _MEIXXX folders are not being deleted due to a bug
+    # https://github.com/pyinstaller/pyinstaller/issues/2379
+
+    # this folder is specified when pyinstaller is run using the --runtime-tmpdir argument. Here pyinstaller creates
+    # _MEIXXX folders with everything needed to run the application
+    temps_dir = os.path.abspath(os.path.join(get_application_path(), 'tmp'))
+    print(f"{temps_dir=}")
+
+    # current _MEIXXX folder
+    current_mei_folder_path = os.path.abspath(get_bundle_path())
+    print(f"{current_mei_folder_path=}")
+
+    for mei_folder_path in [f.name for f in os.scandir(temps_dir) if f.is_dir()]:
+        print(f"{mei_folder_path=}")
+
+        if mei_folder_path == current_mei_folder_path:
+            continue
+        try:
+            shutil.rmtree(mei_folder_path)
+        except Exception as err:
+            print(f"Couldn't delete {mei_folder_path}", err)
+
+
+
+
+

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import sys
+import time
 
 import psutil
 
@@ -27,28 +28,43 @@ def get_net_if_mac_addresses():
                 yield interface, snic.address.lower().replace('-', ':')
 
 
-def clean_runtime_tempdir():
-    # hack to clean the pyinstaller runtime tempdir as the _MEIXXX folders are not being deleted due to a bug
-    # https://github.com/pyinstaller/pyinstaller/issues/2379
+def clean_runtime_tempdir(time_threshold: int = 15*60) -> None:
+    """
+    Windows hack to clean the pyinstaller runtime tempdir as the _MEIXXX folders are not being deleted due to a bug
+    https://github.com/pyinstaller/pyinstaller/issues/2379
 
-    # this folder is specified when pyinstaller is run using the --runtime-tmpdir argument. Here pyinstaller creates
-    # _MEIXXX folders with everything needed to run the application
-    temps_dir = os.path.abspath(os.path.join(get_application_path(), 'tmp'))
-    print(f"{temps_dir=}")
+    :param time_threshold: Delete _MEI folders that were created after this threshold (in seconds). Default is 15min
+    """
+
+    # This hack deletes all _MEI folders created by the connector except the one that is being used by the current
+    # running connector.
+    # As multiple connectors could be running at the same time (1 running as a service and there could also be many
+    # running tests) it is not possible to know which _MEI folders are being used. To avoid deleting folders that
+    # are in use only folders created after time_threshold are deleted.
+    # Also, this hack relies on how Windows handles permissions. When the connector is run as a service its _MEI folder
+    # is created with SYSTEM permissions but when the connector's tests are run the _MEI folders are created with the
+    # current admin user permissions, so when the connector is run as a service it won't be able to delete the tests
+    # _MEI folders and when the connector's tests are run it won't be able to delete the service _MEI folder.
+    # Errors when deleting a folder are ignored.
+
+    if os.name != "nt":     # if OS is not windows then bye
+        return
 
     # current _MEIXXX folder
     current_mei_folder_path = os.path.abspath(get_bundle_path())
-    print(f"{current_mei_folder_path=}")
 
+    # directory that contains the _MEI folders
+    temps_dir = os.path.join(current_mei_folder_path, '..')
+
+    now = time.time()
     for mei_folder_path in [f.path for f in os.scandir(temps_dir) if f.is_dir()]:
-        print(f"{mei_folder_path=}")
-
-        if mei_folder_path == current_mei_folder_path:
+        if (
+                mei_folder_path == current_mei_folder_path or
+                (os.path.isdir(mei_folder_path) and (now-os.path.getctime(mei_folder_path)) <= time_threshold)
+        ):
             continue
-        try:
-            shutil.rmtree(mei_folder_path)
-        except Exception as err:
-            print(f"Couldn't delete {mei_folder_path}", err)
+
+        shutil.rmtree(mei_folder_path, ignore_errors=True)
 
 
 

--- a/utils.py
+++ b/utils.py
@@ -76,7 +76,7 @@ def clean_runtime_tempdir(logger: Logger, time_threshold: int = 15*60) -> None:
             try:
                 shutil.rmtree(mei_folder_path)
             except Exception:
-                logger.exception(f"Couldn't delete {mei_folder_path}")
+                logger.warning(f"Couldn't delete {mei_folder_path}", exc_info=True)
 
 
 

--- a/utils.py
+++ b/utils.py
@@ -57,14 +57,17 @@ def clean_runtime_tempdir(time_threshold: int = 15*60) -> None:
     temps_dir = os.path.abspath(os.path.join(current_mei_folder_path, '..'))
 
     now = time.time()
-    for mei_folder_path in [f.path for f in os.scandir(temps_dir) if f.is_dir()]:
-        if (
-                mei_folder_path == current_mei_folder_path or
-                (os.path.isdir(mei_folder_path) and (now-os.path.getctime(mei_folder_path)) <= time_threshold)
-        ):
-            continue
 
-        shutil.rmtree(mei_folder_path, ignore_errors=True)
+    for dir_entry in os.scandir(temps_dir):
+        if dir_entry.is_dir():
+            mei_folder_path = dir_entry.path
+            if (
+                    mei_folder_path == current_mei_folder_path or
+                    (now-os.path.getctime(mei_folder_path)) <= time_threshold
+            ):
+                continue
+
+            shutil.rmtree(mei_folder_path, ignore_errors=True)
 
 
 

--- a/version.py
+++ b/version.py
@@ -1,4 +1,5 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1"
+
 
 def get_version():
     return __version__


### PR DESCRIPTION
This hack deletes all _MEI folders created by the connector except the one that is being used by the current
running connector.
As multiple connectors could be running at the same time (1 running as a service and there could also be many running tests) it is not possible to know which _MEI folders are being used. To avoid deleting folders that are in use only folders created after time_threshold are deleted.

Also, this hack relies on how Windows handles permissions. When the connector is run as a service its _MEI folder
is created with SYSTEM permissions but when the connector's tests are run the _MEI folders are created with the current admin user permissions, so when the connector is run as a service it won't be able to delete the tests _MEI folders and when the connector's tests are run it won't be able to delete the service _MEI folder.

Errors when deleting a folder are ignored.