### PR TITLE
Bump cryptography from 41.0.4 to 41.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ certifi==2023.7.22
 cffi==1.15.0
 chardet==3.0.4
 coloredlogs==14.0
-cryptography==41.0.6
+cryptography==41.0.7
 deckar01-ratelimit==3.0.2
 dnspython==2.1.0
 email-validator==1.1.1

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.9"
+__version__ = "1.1.10"
 
 
 def get_version():

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.8"
+__version__ = "1.1.9"
 
 
 def get_version():


### PR DESCRIPTION
Bump cryptography from 41.0.4 to 41.0.7

Bumps [cryptography](https://github.com/pyca/cryptography) from 41.0.4 to 41.0.7.
- [Changelog](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/41.0.4...41.0.7)
